### PR TITLE
fix sort-modifiers incorrect behavior example

### DIFF
--- a/docs/rules/sort-modifiers.md
+++ b/docs/rules/sort-modifiers.md
@@ -22,8 +22,10 @@ contract Example {
 
 Examples of **incorrect** code for this rule:
 
+<!-- prettier-ignore-start -->
 ```solidity
 contract Example {
   function f() myModifier public pure virtual override {}
 }
 ```
+<!-- prettier-ignore-end -->

--- a/docs/rules/sort-modifiers.md
+++ b/docs/rules/sort-modifiers.md
@@ -24,6 +24,6 @@ Examples of **incorrect** code for this rule:
 
 ```solidity
 contract Example {
-  function f() public pure virtual override myModifier {}
+  function f() myModifier public pure virtual override {}
 }
 ```


### PR DESCRIPTION
both "correct" and "incorrect" examples are the same