### PR TITLE
Add naming convention for tests

### DIFF
--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -77,6 +77,8 @@ The following modifiers are available:
 - `virtual`
 - `override`
 - `abstract`
+- `noParameters`
+- `hasParameters`
 
 For example, the following configuration enforces camelCase for everything except for type-like entities, which should be in PascalCase:
 

--- a/docs/rules/naming-convention.md
+++ b/docs/rules/naming-convention.md
@@ -78,7 +78,21 @@ The following modifiers are available:
 - `override`
 - `abstract`
 
-For example, the following configuration uses the default naming convention explicitly:
+For example, the following configuration enforces camelCase for everything except for type-like entities, which should be in PascalCase:
+
+````json5
+[
+  {
+    "selector": "default",
+    "format": ["camelCase"],
+    "leadingUnderscore": "allow",
+    "trailingUnderscore": "allow"
+  },
+  {
+    "selector": "typeLike",
+    "format": ["PascalCase"]
+  }
+]
 
 ```js
 export default {
@@ -104,28 +118,50 @@ export default {
     ],
   },
 };
-```
+````
 
 ## Example configs
 
 ### Default config
 
-```json
+```json5
 [
   {
-    "selector": "default",
-    "format": ["camelCase"],
-    "leadingUnderscore": "allow",
-    "trailingUnderscore": "allow"
+    selector: "default",
+    format: ["camelCase"],
+    leadingUnderscore: "allow",
+    trailingUnderscore: "allow",
   },
   {
-    "selector": "typeLike",
-    "format": ["PascalCase"]
+    selector: "typeLike",
+    format: ["PascalCase"],
   },
   {
-    "selector": "enumMember",
-    "format": ["PascalCase"]
-  }
+    selector: "enumMember",
+    format: ["PascalCase"],
+  },
+  // unit tests
+  {
+    selector: "function",
+    modifiers: ["noParameters"],
+    format: null,
+    filter: "^test",
+    custom: {
+      match: true,
+      regex: "^test(Fork)?(_Revert(When|If))?_[A-Za-z0-9]+$",
+    },
+  },
+  // fuzz tests
+  {
+    selector: "function",
+    modifiers: ["hasParameters"],
+    format: null,
+    filter: "^test",
+    custom: {
+      match: true,
+      regex: "^test(Fork)?Fuzz(_Revert(When|If))?_[A-Za-z0-9]+$",
+    },
+  },
 ]
 ```
 

--- a/src/rules/naming-convention.ts
+++ b/src/rules/naming-convention.ts
@@ -177,7 +177,7 @@ const DEFAULT_CONFIG: NamingConventionUserConfig = [
     filter: "^test",
     custom: {
       match: true,
-      regex: "^test(Fork)?(_Revert(When|If))?_[A-Za-z0-9]+$",
+      regex: "^test(Fork)?(_Revert(When|If))?(_[A-Za-z0-9]+)+$",
     },
   },
   // fuzz tests
@@ -188,7 +188,7 @@ const DEFAULT_CONFIG: NamingConventionUserConfig = [
     filter: "^test",
     custom: {
       match: true,
-      regex: "^test(Fork)?Fuzz(_Revert(When|If))?_[A-Za-z0-9]+$",
+      regex: "^test(Fork)?Fuzz(_Revert(When|If))?(_[A-Za-z0-9]+)+$",
     },
   },
 ];

--- a/test/rules/naming-convention.test.ts
+++ b/test/rules/naming-convention.test.ts
@@ -100,7 +100,45 @@ const ruleName = "naming-convention";
 
 const fixtures: RuleTestFixture[] = [
   {
-    description: "naming-convention",
+    description: "default convention",
+    content: `
+    function myFunction() {
+      uint localVariable;
+    }
+
+    error MyError(string myParameter);
+    event MyEvent(string myParameter);
+    enum MyEnum {
+      MyEnumMember,
+      MyOtherEnumMember
+    }
+
+    contract MyContract {}
+    interface MyInterface {}
+    library MyLibrary {}
+
+    contract TestContract {
+      function test_Something() {}
+      function testFork_Something() {}
+      function testFuzz_Something(uint256 x) {}
+      function testForkFuzz_Something(uint256 x) {}
+
+      function test_RevertWhen_Something() {}
+      function test_RevertIf_Something() {}
+
+      function testFork_RevertWhen_Something() {}
+      function testFork_RevertIf_Something() {}
+
+      function testFuzz_RevertWhen_Something(uint256 x) {}
+      function testFuzz_RevertIf_Something(uint256 x) {}
+
+      function testForkFuzz_RevertWhen_Something(uint256 x) {}
+      function testForkFuzz_RevertIf_Something(uint256 x) {}
+    }
+    `,
+  },
+  {
+    description: "should allow selecting contracts",
     content: `
     contract camelCaseContract {}
              ^^^^^^^^^^^^^^^^^
@@ -1366,6 +1404,44 @@ const fixtures: RuleTestFixture[] = [
           selector: "function",
           modifiers: ["pure", "virtual", "override"],
           format: ["snake_case"],
+        },
+      ],
+    ],
+  },
+  {
+    description: "should support the noParameter modifier",
+    content: `
+          contract MyContract {
+            function NoParameters() public {}
+                     ^^^^^^^^^^^^
+            function WithParameters(uint x) public {}
+          }
+        `,
+    config: [
+      [
+        {
+          selector: "function",
+          modifiers: ["noParameters"],
+          format: ["camelCase"],
+        },
+      ],
+    ],
+  },
+  {
+    description: "should support the hasParameters modifier",
+    content: `
+          contract MyContract {
+            function NoParameters() public {}
+            function WithParameters(uint x) public {}
+                     ^^^^^^^^^^^^^^
+          }
+        `,
+    config: [
+      [
+        {
+          selector: "function",
+          modifiers: ["hasParameters"],
+          format: ["camelCase"],
         },
       ],
     ],

--- a/test/rules/naming-convention.test.ts
+++ b/test/rules/naming-convention.test.ts
@@ -119,8 +119,10 @@ const fixtures: RuleTestFixture[] = [
 
     contract TestContract {
       function test_Something() {}
+      function test_Multi_Part_Description() {}
       function testFork_Something() {}
       function testFuzz_Something(uint256 x) {}
+      function testFuzz_Multi_Part_Description(uint256 x) {}
       function testForkFuzz_Something(uint256 x) {}
 
       function test_RevertWhen_Something() {}


### PR DESCRIPTION
Closes #9.

I ended up using a different approach: I added two new modifiers, `noParameters` and `hasParameters`, and used those along with the `function` selector and a regex format.