### PR TITLE
Fix config "files" and "ignores" filtering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -138,15 +138,19 @@ export class BasicConfigLoader implements ConfigLoader {
     };
 
     for (const configObject of this.config) {
+      const slicedFilePath = filePath.startsWith("./")
+        ? filePath.slice(2)
+        : filePath;
+
       if (
         configObject.ignores.length > 0 &&
-        micromatch([filePath], configObject.ignores).length > 0
+        micromatch([slicedFilePath], configObject.ignores).length > 0
       ) {
         continue;
       }
 
       if (configObject.files.length > 0) {
-        if (micromatch([filePath], configObject.files).length === 0) {
+        if (micromatch([slicedFilePath], configObject.files).length === 0) {
           continue;
         }
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -211,6 +211,20 @@ describe("config", function () {
       });
     });
 
+    it("should work with a local object with matching files", function () {
+      const userConfig: UserConfig = {
+        files: ["./path/**/*.js"],
+        rules: { "some-rule": "off" },
+      };
+      const configLoader = BasicConfigLoader.create(userConfig);
+
+      const config = configLoader.loadConfig("./path/to/file.js");
+
+      expect(config).toEqual({
+        rules: { "some-rule": ["off"] },
+      });
+    });
+
     it("should work with an object with no matching files", function () {
       const userConfig: UserConfig = {
         files: ["/path/**/*.js"],
@@ -233,6 +247,20 @@ describe("config", function () {
       const configLoader = BasicConfigLoader.create(userConfig);
 
       const config = configLoader.loadConfig("/path/to/file.js");
+
+      expect(config).toEqual({
+        rules: {},
+      });
+    });
+
+    it("should work with a local object with matching ignores", function () {
+      const userConfig: UserConfig = {
+        ignores: ["./path/**/*.js"],
+        rules: { "some-rule": "off" },
+      };
+      const configLoader = BasicConfigLoader.create(userConfig);
+
+      const config = configLoader.loadConfig("./path/to/file.js");
 
       expect(config).toEqual({
         rules: {},


### PR DESCRIPTION
Hey @fvictorio, so I was trying to integrate Slippy to Solarity and faced an issue that `files` and `ingores` config lines were just skipped, no matter how I configured them.

The issue seems to lie in "./" passed into micromatch. Since `micromatch.isMatch("./a.sol", "*.sol")` yields `false`.

The PR removes this "./" prefix from files where it's present. I've also added several tests to cover this case. Though I didn't dig deeper into the broader Slippy configuration, so might have missed something.

Thanks!